### PR TITLE
Upgrade to UUID based indexing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ Changelog
 0.5 (unreleased)
 ----------------
 
-- Don't let the ``lineage.childsites`` vocabulary fail, if there are multiple
-  childsites with the same id.
+- Upgrade to ``UUID`` basd indexing instead of using the ``id``. The id is not
+  unique and causes problems when multiple lineage subsites with the same id
+  are registered. Furthermore, the uuid can be used to retrieve the lineage
+  childsite object without traversing up the content tree. A upgrade step is
+  included.
   [thet]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 0.5 (unreleased)
 ----------------
 
+- Depend on ``plone.api`` and use it to get the portal object.
+  [thet]
+
 - Add ``chilsiteForContext`` method, which returns the childsite UUID for a
   given context.
   [thet]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 0.5 (unreleased)
 ----------------
 
+- Add ``chilsiteForContext`` method, which returns the childsite UUID for a
+  given context.
+  [thet]
+
 - Upgrade to ``UUID`` basd indexing instead of using the ``id``. The id is not
   unique and causes problems when multiple lineage subsites with the same id
   are registered. Furthermore, the uuid can be used to retrieve the lineage

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires=[
         'setuptools',
         'collective.lineage',
+        'plone.api',
     ],
     entry_points="""
     [z3c.autoinclude.plugin]

--- a/src/lineage/index/configure.zcml
+++ b/src/lineage/index/configure.zcml
@@ -27,4 +27,13 @@
       description="Index for searching content of childsites"
       provides="Products.GenericSetup.interfaces.EXTENSION"/>
 
+  <genericsetup:upgradeStep
+      source="1"
+      destination="2"
+      title="Upgrade to UUID based indexing."
+      description="Rebuild the catalog to reindex UUID values instead the id."
+      profile="lineage.index:default"
+      handler=".upgrades.upgrade_uuid"
+      />
+
 </configure>

--- a/src/lineage/index/index.py
+++ b/src/lineage/index/index.py
@@ -1,14 +1,14 @@
 from Acquisition import aq_base
 from Products.CMFCore.interfaces import IContentish
-from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import utils
 from collective.lineage.interfaces import IChildSite
 from plone.indexer.decorator import indexer
 from plone.uuid.interfaces import IUUID
+import plone.api
 
 
 def getNextChildSite(context, portal):
-    """Returns the nearest parent object implementing INavigationRoot.
+    """Returns the nearest parent object implementing IChildSite.
     Code borrowed from plone.app.layout.navigation.root.getNavigationRootObject
     """
     obj = context
@@ -20,10 +20,10 @@ def getNextChildSite(context, portal):
 
 @indexer(IContentish)
 def childsite(obj):
-    """Return the id of the closest INavigationRoot up the hierarchy or None if
+    """Return the uuid of the closest childsite up the hierarchy or None if
     there is no subsite.
     """
-    portal = getToolByName(obj, 'portal_url').getPortalObject()
+    portal = plone.api.portal.get()
     childsite = getNextChildSite(obj, portal)
 
     if childsite == portal:

--- a/src/lineage/index/index.py
+++ b/src/lineage/index/index.py
@@ -4,6 +4,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import utils
 from collective.lineage.interfaces import IChildSite
 from plone.indexer.decorator import indexer
+from plone.uuid.interfaces import IUUID
 
 
 def getNextChildSite(context, portal):
@@ -29,4 +30,4 @@ def childsite(obj):
         # Index None so that you can get all non-child site content
         return None
 
-    return childsite.id
+    return IUUID(childsite)

--- a/src/lineage/index/profiles/default/metadata.xml
+++ b/src/lineage/index/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1</version>
+  <version>2</version>
   <dependencies>
     <dependency>profile-collective.lineage:default</dependency>
   </dependencies>

--- a/src/lineage/index/upgrades.py
+++ b/src/lineage/index/upgrades.py
@@ -1,0 +1,31 @@
+from Products.CMFCore.utils import getToolByName
+from collective.lineage.interfaces import IChildSite
+import logging
+
+logger = logging.getLogger('lineage.index')
+
+
+def upgrade_uuid(context):
+    """Reindex the childsite index to use UUID instead of id values. This makes
+    it possible to have multiple childsites with the same id in different
+    paths.
+    """
+    index_id = 'childsite'
+
+    cat = getToolByName(context, 'portal_catalog')
+    cat.manage_clearIndex([index_id])
+
+    # Don't reindex the whole catalog, but only the childsites. These are usaly
+    # much less than all the catalog objects together. Thus, this upgrade step
+    # runs fast.
+    brains = cat(
+        object_provides=IChildSite.__identifier__,
+        path=cat.__parent__.getPhysicalPath()
+    )
+    for brain in brains:
+        ob = brain.getObject()
+        ob.reindexObject(idxs=(index_id,))
+        logger.info("Reindex {0} index for {1}.".format(
+            index_id,
+            ob.absolute_url()
+        ))

--- a/src/lineage/index/upgrades.py
+++ b/src/lineage/index/upgrades.py
@@ -13,9 +13,8 @@ def upgrade_uuid(context):
     cat = getToolByName(context, 'portal_catalog')
     cat.delColumn(index_id)
     cat.addColumn(index_id)
-    res = cat.searchResults()
-    for cnt, it in enumerate(res):
-        ob = it.getObject()
+    res = (it.getObject() for it in cat.searchResults())  # generator expr.
+    for cnt, ob in enumerate(res):
         ob.reindexObject(idxs=(index_id,))
         if cnt % 100 == 0:
             # 100-batch

--- a/src/lineage/index/view.py
+++ b/src/lineage/index/view.py
@@ -1,5 +1,7 @@
+from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from plone.memoize.view import memoize_contextless
+from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
 
@@ -16,3 +18,14 @@ class ChildsiteView(BrowserView):
             return vocab.getTerm(key).title
         except LookupError:
             return key
+
+    def childsiteForContext(self, item):
+        """Returns the childsite UUID for a context object by looking up it's
+        brain in the catalog.
+        """
+        childsite = ''
+        cat = getToolByName(self.context, 'portal_catalog')
+        res = cat.searchResults(UID=IUUID(item), path='/')  # TODO: get portal root
+        if res:
+            childsite = res[0].childsite
+        return childsite

--- a/src/lineage/index/view.py
+++ b/src/lineage/index/view.py
@@ -1,9 +1,16 @@
+from Acquisition import aq_parent
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
 from plone.memoize.view import memoize_contextless
 from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
+
+# Special cases
+try:
+    from plone.event.interfaces import IOccurrence
+except ImportError:
+    IOccurrence = None
 
 
 class ChildsiteView(BrowserView):
@@ -24,8 +31,10 @@ class ChildsiteView(BrowserView):
         brain in the catalog.
         """
         childsite = ''
+        if IOccurrence and IOccurrence.providedBy(item):
+            item = aq_parent(item)
         cat = getToolByName(self.context, 'portal_catalog')
-        res = cat.searchResults(UID=IUUID(item, None), path='/')  # TODO: get portal root. TODO: handle occurrences
+        res = cat.searchResults(UID=IUUID(item, None), path='/')  # TODO: get portal root
         if res:
             childsite = res[0].childsite
         return childsite

--- a/src/lineage/index/view.py
+++ b/src/lineage/index/view.py
@@ -5,6 +5,8 @@ from plone.memoize.view import memoize_contextless
 from plone.uuid.interfaces import IUUID
 from zope.component import getUtility
 from zope.schema.interfaces import IVocabularyFactory
+import plone.api
+
 
 # Special cases
 try:
@@ -33,8 +35,9 @@ class ChildsiteView(BrowserView):
         childsite = ''
         if IOccurrence and IOccurrence.providedBy(item):
             item = aq_parent(item)
+        portal = plone.api.portal.get()
         cat = getToolByName(self.context, 'portal_catalog')
-        res = cat.searchResults(UID=IUUID(item, None), path='/')  # TODO: get portal root
+        res = cat(UID=IUUID(item, None), path=portal.getPhysicalPath())
         if res:
             childsite = res[0].childsite
         return childsite

--- a/src/lineage/index/view.py
+++ b/src/lineage/index/view.py
@@ -25,7 +25,7 @@ class ChildsiteView(BrowserView):
         """
         childsite = ''
         cat = getToolByName(self.context, 'portal_catalog')
-        res = cat.searchResults(UID=IUUID(item), path='/')  # TODO: get portal root
+        res = cat.searchResults(UID=IUUID(item, None), path='/')  # TODO: get portal root. TODO: handle occurrences
         if res:
             childsite = res[0].childsite
         return childsite

--- a/src/lineage/index/view.py
+++ b/src/lineage/index/view.py
@@ -8,7 +8,7 @@ class ChildsiteView(BrowserView):
 
     @memoize_contextless
     def titleForKey(self, key):
-        """returns the childsite's title for their vocabulary value.
+        """Returns the childsite's title for their vocabulary value.
         """
         util = getUtility(IVocabularyFactory, 'lineage.childsites')
         vocab = util(self.context)

--- a/src/lineage/index/vocabulary.py
+++ b/src/lineage/index/vocabulary.py
@@ -3,7 +3,8 @@ from collective.lineage.interfaces import IChildSite
 from plone.memoize import ram
 from zope.interface.declarations import directlyProvides
 from zope.schema.interfaces import IVocabularyFactory
-from zope.schema.vocabulary import SimpleTerm, SimpleVocabulary
+from zope.schema.vocabulary import SimpleTerm
+from zope.schema.vocabulary import SimpleVocabulary
 
 
 # cache until next zope restart
@@ -15,15 +16,13 @@ def childSiteVocabulary(context):
     cat = getToolByName(context, 'portal_catalog')
     brains = cat(
         object_provides=IChildSite.__identifier__,
+        path=cat.__parent__.getPhysicalPath(),
         sort_on='sortable_title'
     )
-    set_brains = []
-    terms = []
-    for brain in brains:
-        val = brain.id
-        if val not in set_brains:
-            # vocabulary values and tokens must be unique
-            set_brains.append(val)
-            terms.append(SimpleTerm(value=val, token=val, title=brain.Title))
+    terms = [
+        SimpleTerm(value=brain.UID, token=brain.UID, title=brain.Title)
+        for brain in brains
+    ]
     return SimpleVocabulary(terms)
+
 directlyProvides(childSiteVocabulary, IVocabularyFactory)

--- a/src/lineage/index/vocabulary.py
+++ b/src/lineage/index/vocabulary.py
@@ -5,6 +5,7 @@ from zope.interface.declarations import directlyProvides
 from zope.schema.interfaces import IVocabularyFactory
 from zope.schema.vocabulary import SimpleTerm
 from zope.schema.vocabulary import SimpleVocabulary
+import plone.api
 
 
 # cache until next zope restart
@@ -14,9 +15,10 @@ def childSiteVocabulary(context):
     """returns the available childsites of the portal
     """
     cat = getToolByName(context, 'portal_catalog')
+    portal = plone.api.portal.get()
     brains = cat(
         object_provides=IChildSite.__identifier__,
-        path=cat.__parent__.getPhysicalPath(),
+        path=portal.getPhysicalPath(),
         sort_on='sortable_title'
     )
     terms = [


### PR DESCRIPTION
Upgrade to `UUID` basd indexing instead of using the `id`. The id is not
unique and causes problems when multiple lineage subsites with the same id
are registered. Furthermore, the uuid can be used to retrieve the lineage
childsite object without traversing up the content tree. A upgrade step
is included.

@frisi @jensens this is the better fix than https://github.com/collective/lineage.index/commit/c091f96345fb525853db4951f0cb8651b3ad8abe
i think, it's even safe without modifications for templates using this index, since the vocabularies title didn't change.
